### PR TITLE
Remove lazy_static, use ServiceMetrics struct instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,6 @@ dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -12,7 +12,6 @@ hyper = { version = "0.13.1", default-features = false, features = ["stream"] }
 prometheus = { version = "0.7", features = ["nightly", "process"]}
 tokio = "0.2"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
-lazy_static = "1.4"
 derive_more = "0.99"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]


### PR DESCRIPTION
Hey, this'll probably be my last PR because I'm really happy with how things are working now! This PR replaces the `lazy_static`ed metrics with a `ServicesMetrics` struct so that we can avoid global variables.